### PR TITLE
fix: update commons-lang dependencies for OmegaT 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     packIntoJar 'commons-cli:commons-cli:1.4'
 	implementation 'commons-io:commons-io:2.7'
-	implementation 'commons-lang:commons-lang:2.6'
+	implementation 'org.apache.commons:commons-lang3:3.11'
 	implementation 'org.omegat:lib-mnemonics:1.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ plugin.name=OMT Package Plugin
 plugin.author=Briac Pilpr\u00e9
 plugin.description=https://github.com/briacp/plugin-omt-package
 plugin.link=https://github.com/briacp/plugin-omt-package
-version=1.7.1
+version=1.8.0
 omegatPluginDir=C:/Users/briac/AppData/Roaming/OmegaT/plugins/

--- a/src/main/java/net/briac/omegat/plugin/omt/ProjectFileStorage.java
+++ b/src/main/java/net/briac/omegat/plugin/omt/ProjectFileStorage.java
@@ -20,21 +20,22 @@
  **************************************************************************/
 package net.briac.omegat.plugin.omt;
 
-import gen.core.project.Masks;
-import gen.core.project.Omegat;
-import gen.core.project.Project;
-import org.apache.commons.lang.StringUtils;
-import org.omegat.core.data.ProjectProperties;
-import org.omegat.util.OConsts;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import org.apache.commons.lang3.StringUtils;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.util.OConsts;
+
+import gen.core.project.Masks;
+import gen.core.project.Omegat;
+import gen.core.project.Project;
 
 //import org.omegat.util.ProjectFileStorage.DEFAULT_FOLDER_MARKER;
 


### PR DESCRIPTION
Update build dependencies from `commons-lang` v2 to v3 to match OmegaT 6.1.0. This means that the next version 1.8.0 will be incompatible with older OmegaT.

close #11 